### PR TITLE
Fix data-loss, validation, and fallback bugs in the avatar pipeline

### DIFF
--- a/css/easy-author-avatar-image.css
+++ b/css/easy-author-avatar-image.css
@@ -1,4 +1,4 @@
-#easy_author_avatar_image_delete_btn {
+#easy-author-avatar-image-delete-btn {
 	margin-left: 5px;
 }
 
@@ -26,8 +26,18 @@
 	vertical-align: middle;
 }
 
-.easy-author-avatar-image-hide, .form-table .user-profile-picture {
+/* Utility class toggled by the upload/delete buttons. Needs to win over the
+   .avatar rules core applies to the preview image. */
+.easy-author-avatar-image-hide {
 	display: none !important;
+}
+
+/* Hides core's own Profile Picture row so it isn't duplicated by this plugin's.
+   Core renders that row inline in wp-admin/user-edit.php with no hook to remove it
+   server-side, so CSS is the only option; the stylesheet is enqueued on profile.php
+   and user-edit.php only, so this rule no longer leaks onto other admin screens. */
+.form-table tr.user-profile-picture {
+	display: none;
 }
 
 .easy-author-avatar-img {

--- a/easy-author-avatar-image.php
+++ b/easy-author-avatar-image.php
@@ -16,6 +16,18 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 if ( ! class_exists( 'easy_author_avatar_image' ) ) {
 	class easy_author_avatar_image {
+		/**
+		 * User meta key holding the attachment ID of the custom avatar.
+		 *
+		 * Kept in sync with the literal used in uninstall.php.
+		 */
+		const META_KEY = 'easy-author-avatar-profile-image';
+
+		/**
+		 * Admin screens the profile UI is rendered on.
+		 */
+		const SCREENS = array( 'profile.php', 'user-edit.php' );
+
 		private $plugin_name = 'easy-author-avatar-image';
 		private $version = '1.5.1';
 
@@ -36,7 +48,14 @@ if ( ! class_exists( 'easy_author_avatar_image' ) ) {
 			echo '<meta name="generator" content="easy-author-avatar-image ' . esc_attr( $this->version ) . '">' . "\n";
 		}
 
-		public function enqueue_styles_scripts() {
+		public function enqueue_styles_scripts( $hook_suffix = '' ) {
+
+			// The profile UI only renders on these two screens, so nothing here is needed elsewhere.
+			// wp_enqueue_media() in particular pulls in the whole media modal bundle.
+			if ( ! in_array( $hook_suffix, self::SCREENS, true ) ) {
+				return;
+			}
+
 			wp_enqueue_style( $this->plugin_name, plugin_dir_url(__FILE__) . 'css/easy-author-avatar-image.css', array(), $this->version, 'all' );
 
 			wp_enqueue_media();
@@ -62,14 +81,19 @@ if ( ! class_exists( 'easy_author_avatar_image' ) ) {
 				return false;
 			}
 
-			$avatar     = get_user_meta( $user->ID, 'easy-author-avatar-profile-image', true );
-			$avatar_url = wp_get_attachment_image_url( $avatar );
+			$avatar     = get_user_meta( $user->ID, self::META_KEY, true );
+			$avatar_url = $avatar ? wp_get_attachment_image_url( $avatar, array( 96, 96 ) ) : false;
+
+			// The stored attachment may have been deleted from the media library since it was set.
+			if ( ! $avatar_url ) {
+				$avatar = '';
+			}
 
 			$button_class = ! $avatar_url ? ' easy-author-avatar-image-hide': '';
 			?>
 
 			<div class="easy-author-avatar-image-upload-wrap" id="easy-author-avatar-image-upload-wrap">
-				<input type="hidden" id="easy-author-avatar-image-id" class="easy-author-avatar-image-input" name="easy-author-avatar-image-id" value="<?php echo isset( $avatar ) ? esc_attr( $avatar ) : ''; ?>">
+				<input type="hidden" id="easy-author-avatar-image-id" class="easy-author-avatar-image-input" name="easy-author-avatar-image-id" value="<?php echo esc_attr( $avatar ); ?>">
 				<h2><?php esc_html_e( 'Easy Author Avatar Image', 'easy-author-avatar-image' ); ?></h2>
 
 				<table class="easy-author-avatar-image-form-table">
@@ -77,7 +101,7 @@ if ( ! class_exists( 'easy_author_avatar_image' ) ) {
 						<tr class="easy-author-avatar-image-user-profile-picture">
 							<th><?php esc_html_e( 'Profile Picture', 'easy-author-avatar-image' ); ?></th>
 							<td>
-								<img class="avatar avatar-96 photo easy-author-avatar-img<?php echo esc_attr( $button_class ); ?>" id="easy-author-avatar-image-custom" src="<?php echo isset( $avatar_url ) ? esc_url( $avatar_url ) : ''; ?>" width="96" height="96" alt="" />
+								<img class="avatar avatar-96 photo easy-author-avatar-img<?php echo esc_attr( $button_class ); ?>" id="easy-author-avatar-image-custom" src="<?php echo $avatar_url ? esc_url( $avatar_url ) : ''; ?>" width="96" height="96" alt="" />
 
 								<div class="easy-author-avatar-image-upload-action">
 
@@ -104,45 +128,119 @@ if ( ! class_exists( 'easy_author_avatar_image' ) ) {
 
 		public function author_save_custom_img( $user_id ) {
 
-			if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			// Mirrors the guard in admin_author_img_upload(). Without the upload_files check a user
+			// who was never shown the field would still reach the $_POST read below.
+			if ( ! current_user_can( 'edit_user', $user_id ) || ! current_user_can( 'upload_files' ) ) {
 				return false;
 			}
 
-			/* phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotValidated */
-			update_user_meta( $user_id, 'easy-author-avatar-profile-image', sanitize_text_field( wp_unslash( $_POST['easy-author-avatar-image-id'] ) ) );
+			// The nonce is verified by core in wp-admin/user-edit.php before this hook fires.
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( ! isset( $_POST['easy-author-avatar-image-id'] ) ) {
+				return false;
+			}
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$attachment_id = absint( wp_unslash( $_POST['easy-author-avatar-image-id'] ) );
+
+			// An empty value means the user pressed Delete; remove the row rather than storing ''.
+			if ( ! $attachment_id ) {
+				delete_user_meta( $user_id, self::META_KEY );
+				return true;
+			}
+
+			// Never store an ID that isn't an image attachment.
+			if ( 'attachment' !== get_post_type( $attachment_id ) || ! wp_attachment_is_image( $attachment_id ) ) {
+				return false;
+			}
+
+			update_user_meta( $user_id, self::META_KEY, $attachment_id );
+
+			return true;
 		}
 
 		public function get_easy_author_image( $avatar, $id_or_email, $size, $default, $alt ) {
 
-			$user = false;
+			$user_id = $this->resolve_user_id( $id_or_email );
+
+			if ( ! $user_id ) {
+				return $avatar;
+			}
+
+			$attachment_id = get_user_meta( $user_id, self::META_KEY, true );
+
+			if ( ! $attachment_id ) {
+				return $avatar;
+			}
+
+			$size = absint( $size );
+
+			// Returns false when the attachment has since been deleted, in which case the
+			// default avatar must be left untouched rather than replaced with an empty src.
+			$avatar_url = wp_get_attachment_image_url( $attachment_id, array( $size, $size ) );
+
+			if ( ! $avatar_url ) {
+				return $avatar;
+			}
+
+			return sprintf(
+				"<img alt='%s' src='%s' class='avatar avatar-%d photo' height='%d' width='%d' />",
+				esc_attr( $alt ),
+				esc_url( $avatar_url ),
+				$size,
+				$size,
+				$size
+			);
+		}
+
+		/**
+		 * Resolve the identifier passed to the get_avatar filter into a user ID.
+		 *
+		 * Mirrors the object handling in core's get_avatar_data(): WP_User exposes ID,
+		 * WP_Post exposes post_author, and only WP_Comment exposes user_id.
+		 *
+		 * @param mixed $id_or_email User ID, email address, WP_User, WP_Post or WP_Comment.
+		 * @return int User ID, or 0 when it cannot be resolved.
+		 */
+		private function resolve_user_id( $id_or_email ) {
 
 			if ( is_numeric( $id_or_email ) ) {
-				$id = (int) $id_or_email;
-				$user = get_user_by( 'id' , $id );
-			} elseif ( is_object( $id_or_email ) ) {
-				if ( ! empty( $id_or_email->user_id ) ) {
-					$id = (int) $id_or_email->user_id;
-					$user = get_user_by( 'id' , $id );
-				}
-			} else {
-				$user = get_user_by( 'email', $id_or_email );
+				return absint( $id_or_email );
 			}
 
-			if ( $user && is_object( $user ) ) {
-				$get_avatar = get_user_meta( $user->ID, 'easy-author-avatar-profile-image', true );
-				if ( $get_avatar ) {
-					$avatar_url = wp_get_attachment_image_url( $get_avatar );
-					$avatar = sprintf(
-						"<img alt='%s' src='%s' class='avatar avatar-%d photo' height='%d' width='%d' />",
-						esc_attr( $alt ),
-						esc_url( $avatar_url ),
-						esc_attr( $size ),
-						esc_attr( $size ),
-						esc_attr( $size )
-					);
-				}
+			if ( $id_or_email instanceof WP_User ) {
+				return (int) $id_or_email->ID;
 			}
-			return $avatar;
+
+			if ( $id_or_email instanceof WP_Post ) {
+				return (int) $id_or_email->post_author;
+			}
+
+			if ( $id_or_email instanceof WP_Comment ) {
+				if ( ! empty( $id_or_email->user_id ) ) {
+					return (int) $id_or_email->user_id;
+				}
+
+				// Anonymous commenter: fall back to matching on the address they left.
+				if ( ! empty( $id_or_email->comment_author_email ) ) {
+					$user = get_user_by( 'email', $id_or_email->comment_author_email );
+					return $user ? (int) $user->ID : 0;
+				}
+
+				return 0;
+			}
+
+			// Any other object exposing a user_id, for forward compatibility.
+			if ( is_object( $id_or_email ) && ! empty( $id_or_email->user_id ) ) {
+				return (int) $id_or_email->user_id;
+			}
+
+			if ( is_string( $id_or_email ) && is_email( $id_or_email ) ) {
+				$user = get_user_by( 'email', $id_or_email );
+				return $user ? (int) $user->ID : 0;
+			}
+
+			return 0;
 		}
 
 		public function eaai_plugin_action_links_add_settings( $links ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,13 +24,29 @@ if ( is_multisite() ) {
 		eaai_delete_plugin_option();
 		restore_current_blog();
 	}
+} else {
+	eaai_delete_plugin_option();
 }
 
-eaai_delete_plugin_option();
+// User meta lives in a single network-wide table, so this runs once rather than per site.
+eaai_delete_plugin_user_meta();
 
 /**
  * Delete the current site's option.
+ *
+ * The option was written by the onboarding settings page removed in 1.5. It is still
+ * deleted here so sites upgrading from an earlier version don't leave the row behind.
  */
 function eaai_delete_plugin_option(): void {
 	delete_option( 'easy_author_avatar_image_option' );
+}
+
+/**
+ * Delete every user's stored avatar.
+ *
+ * This is the data the plugin actually creates: one row per user who set a custom
+ * avatar. The $delete_all argument removes the meta key for all users in one query.
+ */
+function eaai_delete_plugin_user_meta(): void {
+	delete_metadata( 'user', 0, 'easy-author-avatar-profile-image', '', true );
 }


### PR DESCRIPTION
Addresses the 1.5.2 bug batch: #19, #20, #21, #22, #23, #25, #26.

## What's fixed

| Issue | Problem | Fix |
|---|---|---|
| #19 | `author_save_custom_img()` read `$_POST` unconditionally, but the field is only rendered for users with `upload_files`. A Contributor/Subscriber updating their profile got an undefined-key warning on PHP 8.0+, a null deprecation on 8.1+, and had any stored avatar overwritten with `''`. | Mirror the render guard, `isset()` check, and `delete_user_meta()` instead of storing an empty string. |
| #20 | The submitted value was stored verbatim — any post ID or arbitrary text. | `absint()`, then reject unless it is a real image attachment. |
| #21 | The default avatar was overwritten even when `wp_get_attachment_image_url()` returned `false`, emitting `<img src=''>` once the attachment was deleted. | Fall through to the default. Same guard applied on the profile screen. |
| #22 | Object resolution only handled `->user_id`, so `WP_User` and `WP_Post` silently fell back to Gravatar. | New `resolve_user_id()` mirroring core's `get_avatar_data()`; also matches anonymous commenters on `comment_author_email`. |
| #23 | `uninstall.php` deleted an option last written before 1.5 and left every user's avatar meta behind. | Delete the user meta for all users. Option cleanup no longer runs twice on multisite; meta deletion runs once, since `usermeta` is network-wide. |
| #25 | Assets — including `wp_enqueue_media()` — loaded on every admin screen. | Limited to `profile.php` and `user-edit.php`. |
| #26 | One CSS rule conflated the plugin's utility class with an override of core's Profile Picture row, under a blanket `!important`. | Split the rules and dropped `!important` from the core-row override. Also fixed the delete-button rule, which used underscores (`#easy_author_avatar_image_delete_btn`) and so had never matched the hyphenated ID. |

## Partial: #24

The requested `$size` is now forwarded to the attachment lookup rather than defaulting to the 150px thumbnail. **#24 stays open** — `srcset` and the `loading`/`decoding` attributes still need the `get_avatar_data` port in #27.

## Note on #26

The issue suggested removing core's Profile Picture row in PHP rather than CSS. Core renders that row inline in `wp-admin/user-edit.php` with no hook to remove it server-side, so CSS remains the only option. It is no longer a problem in practice: with #25 fixed the stylesheet is enqueued only on the two profile screens, so the rule can't leak elsewhere. The rules are now split and commented.

## Also included

A `META_KEY` class constant replaces the meta-key string literal, which appeared in four places. `uninstall.php` still uses the literal, since it runs without the class loaded — there's a comment on both sides noting they're paired.

## Verification

No DB was available in this environment (the docker-compose MySQL isn't running), so this was verified with a stub harness that exercises the changed logic against both `trunk` and this branch. Every bug reproduces on `trunk` and passes here:

```
=== OLD (trunk) ===                          === NEW (branch) ===
#19 PHP notice on profile update    BUGGY    #19 PHP notice on profile update    FIXED
#19 existing avatar preserved       BUGGY    #19 existing avatar preserved       FIXED
#20 arbitrary post ID rejected      BUGGY    #20 arbitrary post ID rejected      FIXED
#21 deleted attachment falls back   BUGGY    #21 deleted attachment falls back   FIXED
#22 WP_User resolves                BUGGY    #22 WP_User resolves                FIXED
#22 WP_Post resolves                BUGGY    #22 WP_Post resolves                FIXED
#24 size forwarded to lookup        BUGGY    #24 size forwarded to lookup        FIXED
```

Plus 26 assertions covering identifier resolution and the save handler's branches. Both files pass `php -l` on 8.3. The harness is scratch tooling and isn't included here — real test infrastructure is #45.

**Not manually exercised in a browser.** The screen-check in #25 and the CSS changes in #26 are worth a quick look on `profile.php` and `user-edit.php` before merge.

## Not included

No version bump or changelog entry — your history keeps those in a separate release commit (`760d77e Release 1.5.1`), so this follows that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
