### PR TITLE
Clarify where custom avatars are displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Easy Author Avatar Image is a WordPress plugin that allows site administrators a
 - Upload custom avatar images for users
 - Supports multiple image formats
 - Integrates with WordPress user profile page
-- Option to display avatars in comments, posts, and author boxes
+- Replaces the default avatar wherever WordPress renders one, including comments and author boxes
 - Fallback to default avatar if no custom image is set
 - Lightweight and easy to use
 


### PR DESCRIPTION
## Summary

- replace the nonexistent display-option claim with the plugin's actual behavior
- clarify that the `get_avatar` filter applies wherever WordPress renders an avatar

Closes #44

## Verification

- `git diff --check`
- confirmed `easy-author-avatar-image.php` registers the `get_avatar` filter unconditionally