### PR TITLE
Add WordPress and PHP requirements to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,8 @@
 Contributors: mukesh27
 Tags: avatar, user profile, gravatar, custom photo, profile
 Donate link: https://www.paypal.com/paypalme/mukeshpanchal27
+Requires at least: 6.8
+Requires PHP: 7.4
 Tested up to: 7.0
 Stable tag: 1.5.1
 License: GPLv2 or later


### PR DESCRIPTION
## Summary

Adds the missing `Requires at least` and `Requires PHP` headers to `readme.txt`, matching the minimum versions already declared in the main plugin file.

## Why

WordPress.org reads these compatibility requirements from `readme.txt`, so keeping them in sync avoids blank or inaccurate requirement information on the plugin directory page.

Fixes #42.

## Validation

- Confirmed the plugin header declares `Requires at least: 6.8` and `Requires PHP: 7.4`.
- Confirmed this PR changes only `readme.txt`.
- Diff: 1 file, 2 additions, 0 deletions.